### PR TITLE
Fix MS JIS and Latin-1 encoding handling

### DIFF
--- a/src/latin1.c
+++ b/src/latin1.c
@@ -38,8 +38,8 @@ char *latin1_to_utf8(uint8_t *latin1, int size)
     if (size < 0) {
 	/* Count output size until we find a terminator/bad char. */
 	output = (char *)latin1;
-	while (table[(unsigned char)*output] != '\0') {
-	    output_size += strlen(table[(unsigned char)*output]);
+	while (*output != '\0') {
+		output_size += strlen(table[(unsigned char)*output++]);
 	}
 	/* And also include the terminator. */
 	output_size++;

--- a/src/msjis.c
+++ b/src/msjis.c
@@ -50,7 +50,7 @@ char *msjis_to_utf8(uint8_t *msjis, int size)
 	    } else if (table[(unsigned char)lo][0] != '\0') {
 		output_size += strlen(table[(unsigned char)lo]);
 	    }
-	} while (table[(unsigned char)lo] != '\0');
+	} while (table[(unsigned char)lo][0] != '\0');
 	/* And also include the terminator. */
 	output_size++;
     } else {


### PR DESCRIPTION
Both encoding handlers have branches that would never have worked and do not compile with modern tooling, but fortunately they are never called.  Fix them anyway.